### PR TITLE
Reexport GlobalDependencies for more ergonomic use of dependency.

### DIFF
--- a/Sources/NetworkDependency/NetworkDependency.swift
+++ b/Sources/NetworkDependency/NetworkDependency.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import GlobalDependencies
+@_exported import GlobalDependencies
 
 /**
  A protocol to adopt for dependencies that require access to the network.


### PR DESCRIPTION
Let's run CI on it.